### PR TITLE
Restore root index for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,50 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Simulateur d’opportunités (minimal · style Notion)</title>
-  <style>
-    /* Palette inspirée de Notion : neutres propres + accent bleu */
-    :root{
-      --bg: transparent; /* laisse Notion gérer le fond */
-      --card-bg:#ffffff; --text:#1f2328; --muted:#667085; --border:#e5e7eb; --accent:#2F80ED;
-      --input-bg:#fff; --input-border:#d1d5db; --kpi-bg:#f7f8fa;
-    }
-    @media (prefers-color-scheme: dark) {
-      :root{
-        --card-bg:#1f1f1f; --text:#f5f7fb; --muted:#a1a1aa; --border:#2a2a2a; --accent:#60a5fa;
-        --input-bg:#151515; --input-border:#2a2a2a; --kpi-bg:#161616;
-      }
-    }
-
-    *{box-sizing:border-box}
-    html,body{height:100%}
-    body{margin:0;font-family:ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, Arial; background:var(--bg); color:var(--text)}
-
-    .wrap{max-width:860px;margin:24px auto;padding:0 16px}
-    .card{background:var(--card-bg);border:1px solid var(--border);border-radius:12px;padding:20px;box-shadow:0 1px 2px rgba(0,0,0,.04)}
-    h1{margin:0 0 6px;font-size:20px;font-weight:700}
-    p{margin:6px 0 16px;color:var(--muted)}
-
-    .grid{display:grid;grid-template-columns:1fr;gap:12px}
-    @media(min-width:880px){.grid{grid-template-columns:repeat(2,1fr)}}
-
-    label{font-size:13px;color:var(--muted)}
-    input{width:100%;padding:10px 12px;border-radius:8px;border:1px solid var(--input-border);background:var(--input-bg);color:var(--text)}
-    input:focus{outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 20%, transparent)}
-
-    .row{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
-    .btn{appearance:none;border:1px solid transparent;border-radius:8px;padding:10px 14px;font-weight:600;cursor:pointer;background:var(--accent);color:#fff}
-    .btn:hover{filter:brightness(.96)}
-    .link{display:inline-block;text-decoration:none;color:var(--text);padding:10px 12px;border-radius:8px;border:1px solid var(--border)}
-    .link:hover{background-color:color-mix(in srgb, var(--accent) 7%, transparent)}
-
-    .kpi{display:grid;grid-template-columns:repeat(2,1fr);gap:10px;margin-top:14px}
-    @media(max-width:640px){.kpi{grid-template-columns:1fr}}
-    .box{padding:12px;border-radius:10px;background:var(--kpi-bg);border:1px solid var(--border)}
-    .box h3{margin:0 0 6px;font-size:12px;color:var(--muted)}
-    .val{font-size:20px;font-weight:800}
-
-    .foot{margin-top:8px;font-size:12px;color:var(--muted)}
-  </style>
+  <link rel="stylesheet" href="src/styles/brand.css" />
+  <link rel="stylesheet" href="src/styles/app.css" />
 </head>
 <body>
   <div class="wrap">
@@ -94,30 +52,41 @@
   </div>
 
   <script>
-    function n(id, def){
+    function n(id, def) {
       const el = document.getElementById(id);
-      const v = parseFloat((el.value||'').replace(',', '.'));
-      return isFinite(v) ? v : def;
+      const v = parseFloat((el.value || '').replace(',', '.'));
+      return Number.isFinite(v) ? v : def;
     }
-    function eur(x){
-      return new Intl.NumberFormat('fr-FR',{style:'currency',currency:'EUR',maximumFractionDigits:0}).format(x||0);
+
+    function eur(value) {
+      return new Intl.NumberFormat('fr-FR', {
+        style: 'currency',
+        currency: 'EUR',
+        maximumFractionDigits: 0,
+      }).format(value || 0);
     }
-    function calc(){
+
+    function calc() {
       const visits = Math.max(0, n('visits', 5000));
       const conv = Math.max(0, Math.min(100, n('conv', 1.5)));
       const aov = Math.max(0, n('aov', 60));
       const delta = Math.max(0, n('delta', 1));
       const adspend = Math.max(0, n('adspend', 0));
 
-      const caActuel = visits * (conv/100) * aov;
-      const gain = visits * (delta/100) * aov;
+      const caActuel = visits * (conv / 100) * aov;
+      const gain = visits * (delta / 100) * aov;
       const caProjete = caActuel + gain;
-      const roi = adspend>0 ? (gain - adspend) / adspend : (gain>0 ? Infinity : 0);
+      const roi = adspend > 0 ? (gain - adspend) / adspend : (gain > 0 ? Infinity : 0);
 
       document.getElementById('caActuel').textContent = eur(caActuel);
       document.getElementById('gain').textContent = eur(gain);
       document.getElementById('caProjete').textContent = eur(caProjete);
-      document.getElementById('roi').textContent = (roi===Infinity? '∞' : new Intl.NumberFormat('fr-FR',{style:'percent',maximumFractionDigits:1}).format(roi));
+      document.getElementById('roi').textContent = roi === Infinity
+        ? '∞'
+        : new Intl.NumberFormat('fr-FR', {
+            style: 'percent',
+            maximumFractionDigits: 1,
+          }).format(roi);
     }
   </script>
 </body>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,0 +1,146 @@
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-regular);
+  background: var(--color-background);
+  color: var(--color-text);
+}
+
+.wrap {
+  max-width: 860px;
+  margin: var(--spacing-xxl) auto;
+  padding: 0 var(--spacing-lg);
+}
+
+.card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-xl);
+  box-shadow: var(--shadow-soft);
+}
+
+h1 {
+  margin: 0 0 var(--spacing-sm);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+}
+
+p {
+  margin: var(--spacing-sm) 0 var(--spacing-lg);
+  color: var(--color-muted);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-md);
+}
+
+@media (min-width: 880px) {
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+label {
+  font-size: var(--font-size-sm);
+  color: var(--color-muted);
+}
+
+input {
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-input-border);
+  background: var(--color-input-bg);
+  color: var(--color-text);
+}
+
+input:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 20%, transparent);
+}
+
+.row {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.btn {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.btn:hover {
+  filter: brightness(0.96);
+}
+
+.link {
+  display: inline-block;
+  text-decoration: none;
+  color: var(--color-text);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+}
+
+.link:hover {
+  background-color: color-mix(in srgb, var(--color-accent) 7%, transparent);
+}
+
+.kpi {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--spacing-md);
+  margin-top: var(--spacing-lg);
+}
+
+@media (max-width: 640px) {
+  .kpi {
+    grid-template-columns: 1fr;
+  }
+}
+
+.box {
+  padding: var(--spacing-md);
+  border-radius: var(--radius-md);
+  background: var(--color-kpi-bg);
+  border: 1px solid var(--color-border);
+}
+
+.box h3 {
+  margin: 0 0 var(--spacing-xs);
+  font-size: var(--font-size-sm);
+  color: var(--color-muted);
+}
+
+.val {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+}
+
+.foot {
+  margin-top: var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  color: var(--color-muted);
+}

--- a/src/styles/brand.css
+++ b/src/styles/brand.css
@@ -1,0 +1,45 @@
+:root {
+  --color-background: transparent;
+  --color-surface: #ffffff;
+  --color-text: #1f2328;
+  --color-muted: #667085;
+  --color-border: #e5e7eb;
+  --color-accent: #2f80ed;
+  --color-input-bg: #ffffff;
+  --color-input-border: #d1d5db;
+  --color-kpi-bg: #f7f8fa;
+
+  --font-family-base: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+  --font-size-base: 16px;
+  --font-size-sm: 13px;
+  --font-size-lg: 20px;
+  --font-weight-regular: 400;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  --spacing-xs: 4px;
+  --spacing-sm: 8px;
+  --spacing-md: 12px;
+  --spacing-lg: 16px;
+  --spacing-xl: 20px;
+  --spacing-xxl: 24px;
+
+  --radius-sm: 8px;
+  --radius-md: 10px;
+  --radius-lg: 12px;
+  --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-surface: #1f1f1f;
+    --color-text: #f5f7fb;
+    --color-muted: #a1a1aa;
+    --color-border: #2a2a2a;
+    --color-accent: #60a5fa;
+    --color-input-bg: #151515;
+    --color-input-border: #2a2a2a;
+    --color-kpi-bg: #161616;
+    --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.32);
+  }
+}


### PR DESCRIPTION
## Summary
- create a brand stylesheet that centralises color, typography, and spacing variables
- extract the simulator layout styles into a dedicated CSS file that consumes the shared tokens
- restore the simulator entry point at the repository root so GitHub Pages continues to serve the app

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c95a1b2c38832094887a3b04fdacbc