### PR TITLE
Refondre l’audit tunnel avec diagnostic complet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,54 @@
 # Simulateur d’opportunités
 
-## État des lieux actuel
+## Aperçu
 
-- **Type d’outil :** simulateur statique côté client permettant d’estimer l’impact d’une amélioration du taux de conversion e-commerce.
-- **Données manipulées :** trafic qualifié mensuel, taux de conversion actuel, panier moyen, amélioration visée et budget publicitaire.
-- **Résultats restitués :** CA actuel, gains potentiels, CA projeté et ROI indicatif.
-- **Technologies** : HTML/CSS/JavaScript natifs, aucune dépendance externe, fonctionnement hors-ligne possible.
+Ce projet fournit un audit express du tunnel commercial B2B. L’interface recueille les volumes clés (visiteurs, leads, devis,
+signatures), calcule automatiquement les taux de conversion, chiffre les gains potentiels et génère un plan d’action priorisé.
+Tous les calculs s’exécutent dans le navigateur ; aucune donnée n’est transmise côté serveur.
 
-## Organisation structurée du projet
+## Fonctionnalités principales
+
+1. **Questionnaire guidé**
+   - Champs numériques avec validations instantanées (valeurs ≥ 0, cohérence V ≥ L ≥ D ≥ S).
+   - Aides contextuelles, badges ✅ / ⚠️ et surlignage automatique des incohérences.
+   - Prise en compte des supports marketing existants, du budget pub, du temps passé à réexpliquer, etc.
+   - Persistance `localStorage` + préremplissage via paramètres d’URL (`?V=...&L=...`).
+
+2. **Diagnostic visuel du tunnel**
+   - Entonnoir interactif avec mise en évidence du maillon faible et comparaison aux benchmarks sectoriels.
+   - Indice de friction “explication” normalisé sur 0–100.
+
+3. **Chiffrage des gains & pertes**
+   - Scénarios +10 % / +20 % sur l’étape limitante ou sur le closing final (sélecteur utilisateur).
+   - Calcul du CA actuel, gains potentiels, ROI publicitaire (si budget renseigné) et objectif custom basé sur ΔCsign.
+   - Estimation du temps perdu et de son coût (avec paramètres commerciaux optionnels).
+
+4. **Benchmarking paramétrable**
+   - Comparaison aux moyennes fictives par secteur (JSON local), scoring pondéré et estimation du manque à gagner.
+
+5. **Plan d’action priorisé**
+   - Génération de 3 recommandations maximum selon l’étape critique et les frictions internes.
+   - Impact, facilité, effort et délai estimés, avec prise en compte des supports déjà disponibles.
+
+6. **Call-to-action & export**
+   - Bouton « Prendre RDV » prérempli avec les paramètres de l’audit.
+   - Export PDF via `window.print()` et mention explicite sur la confidentialité (« Les données restent sur votre appareil »).
+
+## Organisation du projet
 
 ```
 .
-├── index.html              # Structure de la page et points d’ancrage pour les composants
+├── index.html              # Structure de la page et sections fonctionnelles
 ├── assets/
 │   ├── css/
-│   │   └── app.css         # Styles d’interface consommant la charte graphique
+│   │   └── app.css         # Layout et composants (consomme design/charte.css)
 │   └── js/
-│       └── simulator.js    # Logique de calcul (séparable pour d’autres frontends)
+│       └── simulator.js    # Logique métier : validations, calculs, recommandations
 └── design/
-    └── charte.css          # Charte graphique indépendante (couleurs, typos, espacements)
+    └── charte.css          # Charte graphique (tokens couleurs/typos + variantes dark)
 ```
-
-- Le HTML se limite au markup sémantique (sections, formulaires, KPI) et charge les ressources statiques.
-- Le JavaScript encapsule la logique métier dans `compute()` et expose uniquement un listener sur le bouton « Calculer ».
-- La charte graphique est isolée dans `design/charte.css`. Les styles applicatifs de `assets/css/app.css` ne manipulent que des variables définies dans la charte, ce qui facilite le remplacement du thème ou le branchement de styles alternatifs.
-
-## Pistes d’évolution
-
-1. **Validation en direct** : afficher des messages lorsque des champs sont vides ou incohérents.
-2. **Persistances des valeurs** : stocker les entrées utilisateur dans `localStorage` pour retrouver la dernière simulation.
-3. **Export / partage** : générer un résumé PDF ou un lien partageable avec les paramètres saisis.
-4. **Intégration Notion / iframe** : grâce à la séparation logique/charte, réutiliser `simulator.js` dans d’autres environnements.
 
 ## Utilisation
 
-Ouvrir simplement `index.html` dans un navigateur moderne. Aucun build ni serveur n’est requis.
+Aucun build n’est nécessaire. Ouvrez `index.html` dans un navigateur moderne pour lancer l’audit. Les données sont conservées
+localement (et peuvent être exportées via la fonction d’impression du navigateur).

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,7 +1,6 @@
 /*
-  Styles applicatifs (structure & composants) pour le simulateur.
-  Ils consomment exclusivement les variables définies dans design/charte.css
-  afin de faciliter la maintenance ou le rebranding.
+  Styles applicatifs pour l’audit commercial.
+  Les composants consomment les variables définies dans design/charte.css.
 */
 
 * {
@@ -15,51 +14,143 @@ body {
 
 body {
   margin: 0;
+  font-family: var(--font-sans);
+  background: var(--color-background);
+  color: var(--color-text);
 }
 
 main {
-  max-width: 860px;
+  max-width: 1080px;
   margin: var(--space-xl) auto;
-  padding: 0 var(--space-md);
+  padding: 0 var(--space-md) var(--space-xl);
 }
 
-.sim-card {
+.sim-app {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-card);
-  padding: var(--space-lg);
+  padding: var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
 }
 
-.sim-card h1 {
+.sim-header h1 {
   margin: 0 0 var(--space-xs);
-  font-size: 20px;
-  font-weight: 700;
+  font-size: 28px;
 }
 
-.sim-card p {
-  margin: var(--space-xs) 0 var(--space-md);
+.sim-header p {
+  margin: 0 0 var(--space-sm);
   color: var(--color-muted);
 }
 
-.sim-grid {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--space-md);
-}
-
-@media (min-width: 880px) {
-  .sim-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-label {
+.data-notice {
   font-size: 13px;
   color: var(--color-muted);
 }
 
-input[type="number"] {
+.header-actions {
+  margin-top: var(--space-sm);
+}
+
+.sim-btn,
+.sim-link,
+.cta-button {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  background: var(--color-accent);
+  color: #fff;
+  padding: 10px 16px;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+}
+
+.sim-btn:hover,
+.sim-link:hover,
+.cta-button:hover {
+  filter: brightness(0.96);
+}
+
+.sim-link {
+  background: transparent;
+  border-color: var(--color-border);
+  color: var(--color-text);
+}
+
+.sim-link:hover {
+  background: var(--color-highlight);
+}
+
+.sim-section {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.section-title {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: flex-start;
+}
+
+.section-title h2 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.section-title p {
+  margin: var(--space-2xs) 0 0;
+  color: var(--color-muted);
+}
+
+.section-index {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--color-highlight);
+  color: var(--color-accent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--space-md);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+}
+
+.field--full {
+  grid-column: 1 / -1;
+}
+
+.field label,
+.field legend {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.field input[type="number"] {
   width: 100%;
   padding: 10px 12px;
   border-radius: var(--radius-sm);
@@ -68,95 +159,478 @@ input[type="number"] {
   color: var(--color-text);
 }
 
-input[type="number"]:focus {
+.field--invalid input[type="number"] {
+  border-color: var(--color-danger);
+}
+
+.field input[type="number"]:focus {
   outline: none;
   border-color: var(--color-accent);
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 20%, transparent);
 }
 
-.sim-actions {
+.supports-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--space-sm);
+}
+
+.supports-grid label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 500;
+}
+
+.field-hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--color-muted);
+}
+
+.field-error {
+  min-height: 16px;
+  margin: 0;
+  font-size: 12px;
+  color: var(--color-danger);
+}
+
+.validation-summary h3 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.validation-flags {
   display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2xs);
+  margin: var(--space-xs) 0;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-muted);
+}
+
+.badge::before {
+  content: '';
+  font-size: 14px;
+}
+
+.badge[data-state='ok']::before {
+  content: '✅';
+}
+
+.badge[data-state='warn']::before {
+  content: '⚠️';
+}
+
+.badge[data-state='info']::before {
+  content: 'ℹ️';
+}
+
+.badge--ok {
+  border-color: color-mix(in srgb, var(--color-success) 30%, transparent);
+  background: color-mix(in srgb, var(--color-success) 12%, transparent);
+  color: var(--color-success);
+}
+
+.badge--warn {
+  border-color: color-mix(in srgb, var(--color-warning) 40%, transparent);
+  background: color-mix(in srgb, var(--color-warning) 12%, transparent);
+  color: var(--color-warning);
+}
+
+.badge--info {
+  border-color: color-mix(in srgb, var(--color-info) 40%, transparent);
+  background: color-mix(in srgb, var(--color-info) 12%, transparent);
+  color: var(--color-info);
+}
+
+.coherence {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.coherence.ok {
+  color: var(--color-success);
+}
+
+.coherence.warn {
+  color: var(--color-warning);
+}
+
+.funnel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.funnel-steps {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.funnel-step {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) 3fr auto;
   gap: var(--space-sm);
   align-items: center;
-  flex-wrap: wrap;
-}
-
-button.sim-btn {
-  appearance: none;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
   border: 1px solid transparent;
-  border-radius: var(--radius-sm);
-  padding: 10px 14px;
+}
+
+.funnel-step.weakest {
+  border-color: color-mix(in srgb, var(--color-danger) 40%, transparent);
+  background: color-mix(in srgb, var(--color-danger) 12%, transparent);
+}
+
+.step-label {
   font-weight: 600;
-  cursor: pointer;
-  background: var(--color-accent);
-  color: #fff;
 }
 
-button.sim-btn:hover {
-  filter: brightness(0.96);
-}
-
-a.sim-link {
-  display: inline-block;
-  text-decoration: none;
-  color: var(--color-text);
-  padding: 10px 12px;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--color-border);
-}
-
-a.sim-link:hover {
+.step-bar {
+  position: relative;
+  height: 10px;
+  border-radius: 6px;
   background: var(--color-highlight);
+  overflow: hidden;
 }
 
-.sim-kpi {
+.step-fill {
+  position: absolute;
+  inset: 0;
+  transform-origin: left center;
+  background: var(--color-accent);
+  width: 0%;
+}
+
+.step-value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.step-value.good {
+  color: var(--color-success);
+}
+
+.step-value.medium {
+  color: var(--color-warning);
+}
+
+.step-value.low {
+  color: var(--color-danger);
+}
+
+.funnel-message {
+  margin: 0;
+  font-weight: 600;
+}
+
+.friction {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: minmax(160px, auto) 1fr auto;
   gap: var(--space-sm);
-  margin-top: var(--space-md);
+  align-items: center;
 }
 
-@media (max-width: 640px) {
-  .sim-kpi {
+.friction-bar {
+  position: relative;
+  height: 12px;
+  background: var(--color-highlight);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.friction-fill {
+  position: absolute;
+  inset: 0;
+  background: color-mix(in srgb, var(--color-warning) 50%, var(--color-accent) 50%);
+  width: 0%;
+}
+
+.friction-value {
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.scenario-controls {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.scenario-controls label {
+  font-weight: 600;
+}
+
+.sim-tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-sm);
+}
+
+.sim-tile {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  background: var(--color-kpi-background);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+}
+
+.sim-tile h3 {
+  margin: 0;
+  font-size: 14px;
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.sim-value {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.sim-sub {
+  margin: 0;
+  font-size: 12px;
+  color: var(--color-muted);
+}
+
+.benchmark-controls {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.benchmark-controls label {
+  font-weight: 600;
+}
+
+.benchmark-controls select,
+.scenario-controls select {
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-input-border);
+  background: var(--color-input-background);
+}
+
+.benchmark-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.benchmark-table th,
+.benchmark-table td {
+  border-bottom: 1px solid var(--color-border);
+  padding: 10px;
+  text-align: left;
+}
+
+.benchmark-table tbody tr:last-child th,
+.benchmark-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.benchmark-table td[data-verdict] {
+  font-weight: 600;
+}
+
+.verdict-up {
+  color: var(--color-success);
+}
+
+.verdict-mid {
+  color: var(--color-warning);
+}
+
+.verdict-down {
+  color: var(--color-danger);
+}
+
+.benchmark-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-lg);
+  align-items: center;
+}
+
+.score-card {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  padding: var(--space-md);
+  min-width: 180px;
+  background: var(--color-highlight);
+  color: var(--color-accent);
+}
+
+.score-label {
+  display: block;
+  font-size: 12px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.score-value {
+  font-size: 32px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+}
+
+.benchmark-kpis p {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 14px;
+}
+
+.reco-list {
+  margin: 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.reco-list li {
+  background: var(--color-kpi-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  list-style-position: inside;
+}
+
+.reco-list li.reco-empty {
+  border-style: dashed;
+  background: transparent;
+  color: var(--color-muted);
+  font-style: italic;
+  text-align: center;
+}
+
+.reco-title {
+  margin: 0 0 var(--space-2xs);
+  font-weight: 700;
+}
+
+.reco-objective {
+  margin: 0;
+  font-weight: 600;
+}
+
+.reco-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  font-size: 12px;
+  color: var(--color-muted);
+  margin: var(--space-xs) 0 0;
+}
+
+.reco-meta span::before {
+  content: '• ';
+}
+
+.reco-steps {
+  margin: var(--space-xs) 0 0;
+  padding-left: 18px;
+  color: var(--color-muted);
+  font-size: 13px;
+}
+
+.reco-cta {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.cta-text {
+  margin: 0;
+  color: var(--color-text);
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.cta-button {
+  margin-top: var(--space-sm);
+  align-self: flex-start;
+}
+
+@media (max-width: 720px) {
+  main {
+    margin: var(--space-lg) auto;
+    padding: 0 var(--space-sm) var(--space-lg);
+  }
+
+  .sim-app {
+    padding: var(--space-lg);
+  }
+
+  .section-title {
+    flex-direction: column;
+  }
+
+  .funnel-step {
+    grid-template-columns: 1fr;
+    gap: var(--space-2xs);
+  }
+
+  .funnel-step .step-label {
+    order: 0;
+  }
+
+  .funnel-step .step-bar {
+    order: 1;
+  }
+
+  .funnel-step .step-value {
+    order: 2;
+  }
+
+  .friction {
     grid-template-columns: 1fr;
   }
 }
 
-.sim-box {
-  padding: var(--space-md);
-  border-radius: var(--radius-md);
-  background: var(--color-kpi-background);
-  border: 1px solid var(--color-border);
-}
+@media print {
+  body {
+    background: #fff;
+  }
 
-.sim-box h2 {
-  margin: 0 0 var(--space-xs);
-  font-size: 12px;
-  color: var(--color-muted);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
+  main {
+    margin: 0;
+    padding: 0;
+  }
 
-.sim-box .sim-value {
-  font-size: 20px;
-  font-weight: 800;
-}
+  .sim-app {
+    border: none;
+    box-shadow: none;
+    padding: 24px;
+    gap: 24px;
+  }
 
-.sim-footnote {
-  margin-top: var(--space-xs);
-  font-size: 12px;
-  color: var(--color-muted);
-}
+  .sim-section,
+  .sim-header {
+    break-inside: avoid;
+  }
 
-.visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+  .header-actions,
+  #refreshRecommendations {
+    display: none !important;
+  }
 }

--- a/assets/js/simulator.js
+++ b/assets/js/simulator.js
@@ -1,63 +1,908 @@
 /**
- * Logique du simulateur d'opportunités.
- * Séparée du markup afin de pouvoir brancher d'autres interfaces (Notion, app…).
+ * Audit du tunnel commercial — logique côté navigateur.
+ * Tous les calculs sont effectués localement, aucune donnée n’est transmise.
  */
 
-const elements = {
-  visits: document.getElementById('visits'),
-  conversion: document.getElementById('conv'),
-  averageOrder: document.getElementById('aov'),
-  delta: document.getElementById('delta'),
-  adspend: document.getElementById('adspend'),
-  outputs: {
-    currentRevenue: document.getElementById('caActuel'),
-    gain: document.getElementById('gain'),
-    projectedRevenue: document.getElementById('caProjete'),
-    roi: document.getElementById('roi')
-  },
-  calculate: document.getElementById('calculate')
+const STORAGE_KEY = 'audit-tunnel-state-v1';
+const CTA_BASE_URL = 'https://nexus-strategie.fr/Nexus-26fc5cfed6a88039a83beff4f81756fa';
+const CTA_HASH = '#26fc5cfed6a88056a43cf40d86a8200a';
+
+const DEFAULT_STATE = {
+  visitors: '',
+  leads: '',
+  quotes: '',
+  signatures: '',
+  averageOrder: '',
+  supports: [],
+  reExplain: '',
+  adBudget: '',
+  deltaSign: '',
+  nbSales: '',
+  hourlyRate: '',
+  scenarioMode: 'weak',
+  sector: 'general'
 };
 
-function readNumber(input, fallback) {
-  const parsed = parseFloat(String(input.value ?? '').replace(',', '.'));
-  return Number.isFinite(parsed) ? parsed : fallback;
+const REQUIRED_FIELDS = new Set(['visitors', 'leads', 'quotes', 'signatures', 'averageOrder', 'reExplain']);
+const INTEGER_FIELDS = new Set(['visitors', 'leads', 'quotes', 'signatures', 'nbSales']);
+const NUMERIC_FIELDS = new Set([
+  'visitors',
+  'leads',
+  'quotes',
+  'signatures',
+  'averageOrder',
+  'reExplain',
+  'adBudget',
+  'deltaSign',
+  'nbSales',
+  'hourlyRate'
+]);
+
+const BENCHMARKS = {
+  general: {
+    label: 'Général B2B',
+    rates: { tc1: 0.02, tc2: 0.5, tc3: 0.35 }
+  },
+  industrie: {
+    label: 'Industrie',
+    rates: { tc1: 0.015, tc2: 0.45, tc3: 0.3 }
+  },
+  services: {
+    label: 'Services B2B',
+    rates: { tc1: 0.03, tc2: 0.55, tc3: 0.38 }
+  },
+  equipementiers: {
+    label: 'Équipementiers',
+    rates: { tc1: 0.018, tc2: 0.48, tc3: 0.33 }
+  }
+};
+
+const STEP_LABELS = {
+  tc1: 'Visiteurs → Leads',
+  tc2: 'Leads → Devis',
+  tc3: 'Devis → Signatures'
+};
+
+const currencyFormatter = new Intl.NumberFormat('fr-FR', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 0
+});
+
+const percentFormatter = new Intl.NumberFormat('fr-FR', {
+  style: 'percent',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 1
+});
+
+const numberFormatter = new Intl.NumberFormat('fr-FR', {
+  maximumFractionDigits: 1,
+  minimumFractionDigits: 0
+});
+
+const badgeLabels = {
+  visitors: 'Visiteurs',
+  leads: 'Leads',
+  quotes: 'Devis',
+  signatures: 'Signatures',
+  averageOrder: 'Panier moyen',
+  reExplain: 'Frictions'
+};
+
+const fieldElements = {
+  visitors: { input: document.getElementById('visitors'), error: document.querySelector('[data-error="visitors"]'), wrapper: document.querySelector('[data-field="visitors"]') },
+  leads: { input: document.getElementById('leads'), error: document.querySelector('[data-error="leads"]'), wrapper: document.querySelector('[data-field="leads"]') },
+  quotes: { input: document.getElementById('quotes'), error: document.querySelector('[data-error="quotes"]'), wrapper: document.querySelector('[data-field="quotes"]') },
+  signatures: { input: document.getElementById('signatures'), error: document.querySelector('[data-error="signatures"]'), wrapper: document.querySelector('[data-field="signatures"]') },
+  averageOrder: { input: document.getElementById('averageOrder'), error: document.querySelector('[data-error="averageOrder"]'), wrapper: document.querySelector('[data-field="averageOrder"]') },
+  reExplain: { input: document.getElementById('reExplain'), error: document.querySelector('[data-error="reExplain"]'), wrapper: document.querySelector('[data-field="reExplain"]') },
+  adBudget: { input: document.getElementById('adBudget'), error: document.querySelector('[data-error="adBudget"]'), wrapper: document.querySelector('[data-field="adBudget"]') },
+  deltaSign: { input: document.getElementById('deltaSign'), error: document.querySelector('[data-error="deltaSign"]'), wrapper: document.querySelector('[data-field="deltaSign"]') },
+  nbSales: { input: document.getElementById('nbSales'), error: document.querySelector('[data-error="nbSales"]'), wrapper: document.querySelector('[data-field="nbSales"]') },
+  hourlyRate: { input: document.getElementById('hourlyRate'), error: document.querySelector('[data-error="hourlyRate"]'), wrapper: document.querySelector('[data-field="hourlyRate"]') }
+};
+
+const summaryBadges = {
+  visitors: document.querySelector('[data-summary-badge="visitors"]'),
+  leads: document.querySelector('[data-summary-badge="leads"]'),
+  quotes: document.querySelector('[data-summary-badge="quotes"]'),
+  signatures: document.querySelector('[data-summary-badge="signatures"]'),
+  averageOrder: document.querySelector('[data-summary-badge="averageOrder"]'),
+  reExplain: document.querySelector('[data-summary-badge="reExplain"]')
+};
+
+const supportsInputs = Array.from(document.querySelectorAll('input[name="supports"]'));
+const scenarioSelect = document.getElementById('scenarioMode');
+const sectorSelect = document.getElementById('sector');
+const coherenceBadge = document.getElementById('coherenceBadge');
+const exportButton = document.getElementById('export');
+const ctaButton = document.getElementById('cta');
+
+const funnelSteps = {
+  tc1: {
+    container: document.querySelector('[data-step="tc1"]'),
+    fill: document.querySelector('[data-step="tc1"] .step-fill'),
+    value: document.querySelector('[data-tc="tc1"]')
+  },
+  tc2: {
+    container: document.querySelector('[data-step="tc2"]'),
+    fill: document.querySelector('[data-step="tc2"] .step-fill'),
+    value: document.querySelector('[data-tc="tc2"]')
+  },
+  tc3: {
+    container: document.querySelector('[data-step="tc3"]'),
+    fill: document.querySelector('[data-step="tc3"] .step-fill'),
+    value: document.querySelector('[data-tc="tc3"]')
+  }
+};
+
+const weakLinkMessage = document.getElementById('weakLinkMessage');
+const frictionFill = document.querySelector('.friction-fill');
+const frictionValue = document.getElementById('frictionValue');
+
+const tiles = {
+  currentRevenue: document.getElementById('currentRevenue'),
+  timeLost: document.getElementById('timeLostSummary'),
+  timeCost: document.getElementById('timeCostSummary'),
+  gain10: document.getElementById('gain10'),
+  gain20: document.getElementById('gain20'),
+  ca10: document.getElementById('ca10'),
+  ca20: document.getElementById('ca20'),
+  customGain: document.getElementById('customGain'),
+  customCa: document.getElementById('customCa'),
+  roi10: document.getElementById('roi10'),
+  roi20: document.getElementById('roi20'),
+  customTile: document.getElementById('customGainTile'),
+  roiTile: document.getElementById('roiTile')
+};
+
+const benchmarkCells = {
+  tc1: {
+    benchmark: document.querySelector('[data-benchmark="tc1"]'),
+    actual: document.querySelector('[data-actual="tc1"]'),
+    verdict: document.querySelector('[data-verdict="tc1"]')
+  },
+  tc2: {
+    benchmark: document.querySelector('[data-benchmark="tc2"]'),
+    actual: document.querySelector('[data-actual="tc2"]'),
+    verdict: document.querySelector('[data-verdict="tc2"]')
+  },
+  tc3: {
+    benchmark: document.querySelector('[data-benchmark="tc3"]'),
+    actual: document.querySelector('[data-actual="tc3"]'),
+    verdict: document.querySelector('[data-verdict="tc3"]')
+  }
+};
+
+const benchmarkSummary = {
+  globalScore: document.getElementById('globalScore'),
+  benchmarkRevenue: document.getElementById('benchmarkRevenue'),
+  lostRevenue: document.getElementById('lostRevenue')
+};
+
+const recoList = document.getElementById('recoList');
+const refreshRecommendationsButton = document.getElementById('refreshRecommendations');
+
+let formState = deepClone(DEFAULT_STATE);
+let lastWeakestStep = 'tc3';
+
+const RECOMMENDATIONS = {
+  tc1: [
+    {
+      id: 'clarify-promise',
+      title: 'Clarifier la promesse + CTA',
+      objective: 'Renforcer la conversion Visiteur → Lead',
+      steps: ['Reformuler la proposition de valeur en une phrase claire', 'Positionner un CTA visible sur les pages à trafic', 'Tester une variante courte du formulaire'],
+      effort: 'M',
+      duration: '2 semaines',
+      impact: 5,
+      ease: 3,
+      boostSupports: ['Site']
+    },
+    {
+      id: 'lead-magnets',
+      title: 'Créer des aimants à prospects',
+      objective: 'Capturer davantage de leads qualifiés',
+      steps: ['Identifier 1 contenu premium (guide, modèle, check-list)', 'Créer un formulaire court en 3 champs maximum', 'Programmer une séquence d’email de bienvenue'],
+      effort: 'M',
+      duration: '3 semaines',
+      impact: 4,
+      ease: 3,
+      boostSupports: ['Emailing', 'Site']
+    },
+    {
+      id: 'nurturing',
+      title: 'Relances emailing / retargeting',
+      objective: 'Rattraper les visiteurs non convertis',
+      steps: ['Segmenter les visiteurs clés (pages produits, pricing…)', 'Déployer une campagne retargeting simple', 'Envoyer une relance email avec preuve sociale'],
+      effort: 'M',
+      duration: '4 semaines',
+      impact: 4,
+      ease: 2,
+      boostSupports: ['Emailing', 'Plaquette']
+    }
+  ],
+  tc2: [
+    {
+      id: 'qualification-script',
+      title: 'Structurer la qualification',
+      objective: 'Améliorer le passage Lead → Devis',
+      steps: ['Formaliser un script de découverte (5 questions clés)', 'Définir les critères MQL/SQL partagés', 'Suivre les conversions par persona/segment'],
+      effort: 'M',
+      duration: '2 semaines',
+      impact: 5,
+      ease: 3,
+      boostSupports: ['Scripts commerciaux']
+    },
+    {
+      id: 'standardised-proposals',
+      title: 'Standardiser les devis',
+      objective: 'Rendre l’offre plus lisible et rassurante',
+      steps: ['Créer un template clair avec prix / options', 'Ajouter FAQ objections + bénéfices clés', 'Insérer cas clients ou témoignages visuels'],
+      effort: 'M',
+      duration: '3 semaines',
+      impact: 4,
+      ease: 2,
+      boostSupports: ['Plaquette']
+    },
+    {
+      id: 'guided-demo',
+      title: 'Démo guidée / cas clients',
+      objective: 'Accélérer la décision après la prise de contact',
+      steps: ['Sélectionner 2 cas clients représentatifs', 'Préparer un déroulé de démo en 5 étapes', 'Envoyer un récap visuel après chaque échange'],
+      effort: 'M',
+      duration: '3 semaines',
+      impact: 4,
+      ease: 2,
+      boostSupports: ['Plaquette', 'Site']
+    }
+  ],
+  tc3: [
+    {
+      id: 'follow-up-sequences',
+      title: 'Séquences de relance automatisées',
+      objective: 'Maximiser le closing sur Devis → Signatures',
+      steps: ['Programmer des relances J+2, J+7 et J+21', 'Varier les angles : rappel bénéfices, objection, urgence', 'Tracer les réponses dans le CRM pour adapter les scripts'],
+      effort: 'S',
+      duration: '1 semaine',
+      impact: 5,
+      ease: 3,
+      boostSupports: ['Emailing']
+    },
+    {
+      id: 'objection-checklist',
+      title: 'Check-list objections + garanties',
+      objective: 'Réassurer les prospects indécis',
+      steps: ['Lister les 5 objections majeures rencontrées', 'Associer preuve / garantie à chaque objection', 'Partager la check-list avec l’équipe commerciale'],
+      effort: 'S',
+      duration: '1 semaine',
+      impact: 4,
+      ease: 3,
+      boostSupports: ['Scripts commerciaux']
+    },
+    {
+      id: 'price-reassurance',
+      title: 'Réassurance prix & valeur',
+      objective: 'Défendre la valeur sans rogner les marges',
+      steps: ['Comparer votre offre à 2 alternatives marché', 'Mettre en avant garanties, délais et ROI', 'Préparer une option “entrée de gamme” maîtrisée'],
+      effort: 'M',
+      duration: '2 semaines',
+      impact: 4,
+      ease: 2,
+      boostSupports: ['Plaquette']
+    }
+  ],
+  friction: [
+    {
+      id: 'pitch-script',
+      title: 'Script pitch + FAQ interne',
+      objective: 'Réduire le temps passé à réexpliquer',
+      steps: ['Formaliser un pitch de 90 secondes', 'Documenter les réponses aux 10 questions récurrentes', 'Partager le script dans un format accessible (Notion, PDF)'],
+      effort: 'S',
+      duration: '1 semaine',
+      impact: 3,
+      ease: 3,
+      boostSupports: ['Scripts commerciaux']
+    },
+    {
+      id: 'explainer-videos',
+      title: 'Mini-vidéos explicatives',
+      objective: 'Automatiser la pédagogie produit',
+      steps: ['Identifier les notions les plus complexes', 'Tourner 3 vidéos courtes (2-3 minutes)', 'Partager le contenu dans vos emails de suivi'],
+      effort: 'M',
+      duration: '3 semaines',
+      impact: 3,
+      ease: 2,
+      boostSupports: ['Site', 'Emailing']
+    },
+    {
+      id: 'sales-training',
+      title: 'Formation express commerciaux',
+      objective: 'Aligner les messages et réponses clés',
+      steps: ['Organiser un atelier de 2 heures avec l’équipe', 'Jouer 3 scénarios d’objection réels', 'Définir un plan d’amélioration individuel'],
+      effort: 'M',
+      duration: '2 semaines',
+      impact: 4,
+      ease: 1,
+      boostSupports: ['Autre']
+    }
+  ]
+};
+
+function deepClone(source) {
+  return JSON.parse(JSON.stringify(source));
+}
+
+function toNumber(value) {
+  if (value === null || value === undefined) {
+    return 0;
+  }
+  const normalized = String(value).replace(',', '.').trim();
+  if (normalized === '') {
+    return 0;
+  }
+  const parsed = Number.parseFloat(normalized);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
 }
 
 function formatCurrency(value) {
-  return new Intl.NumberFormat('fr-FR', {
-    style: 'currency',
-    currency: 'EUR',
-    maximumFractionDigits: 0
-  }).format(value || 0);
+  if (!Number.isFinite(value)) {
+    return '—';
+  }
+  return currencyFormatter.format(value);
 }
 
 function formatPercent(value) {
-  if (value === Infinity) {
-    return '∞';
+  if (!Number.isFinite(value)) {
+    return '—';
+  }
+  return percentFormatter.format(value);
+}
+
+function formatNumber(value) {
+  if (!Number.isFinite(value)) {
+    return '—';
+  }
+  return numberFormatter.format(value);
+}
+
+function loadStateFromStorage() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return;
+    }
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') {
+      formState = { ...deepClone(DEFAULT_STATE), ...parsed };
+      if (!Array.isArray(formState.supports)) {
+        formState.supports = [];
+      }
+    }
+  } catch (error) {
+    // Stockage non disponible, on reste sur l’état par défaut.
+  }
+}
+
+function applyQueryParams() {
+  const params = new URLSearchParams(window.location.search);
+  if (params.size === 0) {
+    return;
   }
 
-  return new Intl.NumberFormat('fr-FR', {
-    style: 'percent',
-    maximumFractionDigits: 1
-  }).format(value);
+  const mapping = {
+    V: 'visitors',
+    L: 'leads',
+    D: 'quotes',
+    S: 'signatures',
+    PM: 'averageOrder',
+    TR: 'reExplain',
+    B: 'adBudget',
+    Delta: 'deltaSign',
+    DeltaCsign: 'deltaSign'
+  };
+
+  params.forEach((value, key) => {
+    const target = mapping[key];
+    if (target) {
+      formState[target] = value;
+    }
+  });
+
+  const scenario = params.get('scenarioMode');
+  if (scenario && (scenario === 'weak' || scenario === 'tc3')) {
+    formState.scenarioMode = scenario;
+  }
+  const sector = params.get('sector');
+  if (sector && BENCHMARKS[sector]) {
+    formState.sector = sector;
+  }
 }
 
-function compute() {
-  const visits = Math.max(0, readNumber(elements.visits, 5000));
-  const conversion = Math.max(0, Math.min(100, readNumber(elements.conversion, 1.5)));
-  const averageOrder = Math.max(0, readNumber(elements.averageOrder, 60));
-  const delta = Math.max(0, readNumber(elements.delta, 1));
-  const adspend = Math.max(0, readNumber(elements.adspend, 0));
+function syncFormWithState() {
+  Object.entries(fieldElements).forEach(([name, refs]) => {
+    if (refs.input) {
+      refs.input.value = formState[name] ?? '';
+    }
+  });
 
-  const currentRevenue = visits * (conversion / 100) * averageOrder;
-  const gain = visits * (delta / 100) * averageOrder;
-  const projectedRevenue = currentRevenue + gain;
-  const roi = adspend > 0 ? (gain - adspend) / adspend : (gain > 0 ? Infinity : 0);
+  supportsInputs.forEach((input) => {
+    input.checked = formState.supports.includes(input.value);
+  });
 
-  elements.outputs.currentRevenue.textContent = formatCurrency(currentRevenue);
-  elements.outputs.gain.textContent = formatCurrency(gain);
-  elements.outputs.projectedRevenue.textContent = formatCurrency(projectedRevenue);
-  elements.outputs.roi.textContent = formatPercent(roi);
+  scenarioSelect.value = formState.scenarioMode;
+  sectorSelect.value = formState.sector;
 }
 
-elements.calculate.addEventListener('click', compute);
+function saveState() {
+  try {
+    const payload = { ...formState, supports: Array.from(formState.supports) };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    // Silencieusement ignoré si le stockage n’est pas disponible.
+  }
+}
+
+function getNumericState() {
+  const numeric = {};
+  NUMERIC_FIELDS.forEach((field) => {
+    numeric[field] = toNumber(formState[field]);
+  });
+  return numeric;
+}
+
+function computeConversions(numericState) {
+  const tc1 = numericState.visitors > 0 ? clamp(numericState.leads / numericState.visitors, 0, 1) : 0;
+  const tc2 = numericState.leads > 0 ? clamp(numericState.quotes / numericState.leads, 0, 1) : 0;
+  const tc3 = numericState.quotes > 0 ? clamp(numericState.signatures / numericState.quotes, 0, 1) : 0;
+  return { tc1, tc2, tc3 };
+}
+
+function validateInputs(numericState) {
+  const errors = {};
+  Object.keys(fieldElements).forEach((field) => {
+    errors[field] = [];
+  });
+
+  const coherenceIssues = [];
+
+  for (const field of NUMERIC_FIELDS) {
+    const raw = (formState[field] ?? '').toString().trim();
+    if (REQUIRED_FIELDS.has(field) && raw === '') {
+      errors[field].push('Champ requis pour le diagnostic.');
+      continue;
+    }
+    if (raw === '') {
+      continue;
+    }
+
+    if (numericState[field] < 0) {
+      errors[field].push('Valeur négative impossible.');
+    }
+
+    if (INTEGER_FIELDS.has(field) && !Number.isInteger(numericState[field])) {
+      errors[field].push('Veuillez saisir un entier.');
+    }
+
+    if (field === 'deltaSign' && numericState[field] > 100) {
+      errors[field].push('Maximum 100 points de pourcentage.');
+    }
+  }
+
+  if (numericState.leads > numericState.visitors) {
+    errors.leads.push('Ne peut pas dépasser les visiteurs.');
+    coherenceIssues.push('L doit être ≤ V');
+  }
+  if (numericState.quotes > numericState.leads) {
+    errors.quotes.push('Ne peut pas dépasser les leads.');
+    coherenceIssues.push('D doit être ≤ L');
+  }
+  if (numericState.signatures > numericState.quotes) {
+    errors.signatures.push('Ne peut pas dépasser les devis.');
+    coherenceIssues.push('S doit être ≤ D');
+  }
+
+  return { errors, coherenceIssues };
+}
+
+function renderValidation(validation) {
+  Object.entries(validation.errors).forEach(([field, messages]) => {
+    const refs = fieldElements[field];
+    if (!refs) {
+      return;
+    }
+    const hasError = messages.length > 0;
+    if (refs.error) {
+      refs.error.textContent = hasError ? messages.join(' ') : '';
+    }
+    if (refs.wrapper) {
+      refs.wrapper.classList.toggle('field--invalid', hasError);
+    }
+    if (refs.input) {
+      refs.input.setAttribute('aria-invalid', hasError ? 'true' : 'false');
+    }
+  });
+
+  Object.entries(summaryBadges).forEach(([field, badge]) => {
+    const messages = validation.errors[field] ?? [];
+    const isFilled = (formState[field] ?? '').toString().trim() !== '';
+    const status = messages.length === 0 && isFilled ? 'ok' : 'warn';
+    badge.textContent = badgeLabels[field];
+    badge.dataset.state = status;
+    badge.classList.toggle('badge--ok', status === 'ok');
+    badge.classList.toggle('badge--warn', status === 'warn');
+    badge.classList.remove('badge--info');
+  });
+
+  if (validation.coherenceIssues.length === 0) {
+    coherenceBadge.textContent = '✅ Données cohérentes.';
+    coherenceBadge.className = 'coherence ok';
+  } else {
+    coherenceBadge.textContent = `⚠️ Vérifier vos chiffres (${validation.coherenceIssues.join(', ')}).`;
+    coherenceBadge.className = 'coherence warn';
+  }
+}
+
+function determineWeakestStep(conversions, numericState) {
+  const denominators = {
+    tc1: numericState.visitors,
+    tc2: numericState.leads,
+    tc3: numericState.quotes
+  };
+
+  const availableSteps = Object.entries(denominators)
+    .filter(([, value]) => value > 0)
+    .map(([step]) => step);
+
+  if (availableSteps.length === 0) {
+    return { weakestStep: 'tc3', availableSteps: [] };
+  }
+
+  let weakestStep = availableSteps[0];
+  let weakestValue = conversions[weakestStep];
+  availableSteps.forEach((step) => {
+    if (conversions[step] < weakestValue) {
+      weakestStep = step;
+      weakestValue = conversions[step];
+    }
+  });
+
+  return { weakestStep, availableSteps };
+}
+
+function renderFunnel(conversions, numericState) {
+  const benchmark = BENCHMARKS[formState.sector] ?? BENCHMARKS.general;
+  const { weakestStep, availableSteps } = determineWeakestStep(conversions, numericState);
+  lastWeakestStep = weakestStep;
+  const denominators = {
+    tc1: numericState.visitors,
+    tc2: numericState.leads,
+    tc3: numericState.quotes
+  };
+
+  Object.entries(funnelSteps).forEach(([step, refs]) => {
+    const percentValue = conversions[step] * 100;
+    refs.fill.style.width = `${clamp(percentValue, 0, 100)}%`;
+    const hasData = denominators[step] > 0;
+    refs.value.textContent = hasData ? formatPercent(conversions[step]) : '—';
+    refs.value.classList.remove('good', 'medium', 'low');
+    refs.container.classList.remove('weakest');
+
+    const benchmarkValue = benchmark.rates[step];
+    let statusClass = 'low';
+    if (conversions[step] >= benchmarkValue) {
+      statusClass = 'good';
+    } else if (conversions[step] >= benchmarkValue * 0.7) {
+      statusClass = 'medium';
+    }
+
+    if (availableSteps.length > 0 && hasData) {
+      refs.value.classList.add(statusClass);
+    }
+  });
+
+  if (availableSteps.length > 0) {
+    funnelSteps[weakestStep].container.classList.add('weakest');
+    weakLinkMessage.textContent = `Votre principal point de fuite est ${STEP_LABELS[weakestStep]}.`;
+  } else {
+    weakLinkMessage.textContent = 'Renseignez vos volumes pour visualiser votre tunnel.';
+  }
+
+  const frictionScore = clamp(Math.round((numericState.reExplain / 10) * 100), 0, 100);
+  frictionFill.style.width = `${frictionScore}%`;
+  frictionValue.textContent = `${frictionScore} / 100`;
+}
+
+function projectFlow(numericState, conversions, step, factor) {
+  const result = {
+    leads: numericState.leads,
+    quotes: numericState.quotes,
+    signatures: numericState.signatures
+  };
+
+  const safeFactor = Math.max(factor, 0);
+
+  if (step === 'tc1') {
+    const newLeads = Math.min(numericState.visitors, numericState.leads * safeFactor);
+    const newQuotes = newLeads * conversions.tc2;
+    const newSignatures = newQuotes * conversions.tc3;
+    result.leads = newLeads;
+    result.quotes = newQuotes;
+    result.signatures = newSignatures;
+  } else if (step === 'tc2') {
+    const newQuotes = Math.min(numericState.leads, numericState.quotes * safeFactor);
+    const newSignatures = newQuotes * conversions.tc3;
+    result.quotes = newQuotes;
+    result.signatures = newSignatures;
+  } else {
+    const newSignatures = Math.min(numericState.quotes, numericState.signatures * safeFactor);
+    result.signatures = newSignatures;
+  }
+
+  return result;
+}
+
+function renderChiffrage(numericState, conversions) {
+  const scenarioTarget = formState.scenarioMode === 'tc3' ? 'tc3' : lastWeakestStep;
+  const caActuel = numericState.signatures * numericState.averageOrder;
+  const nbSales = numericState.nbSales > 0 ? numericState.nbSales : 1;
+  const hourlyRate = numericState.hourlyRate > 0 ? numericState.hourlyRate : 50;
+  const hoursLost = numericState.reExplain * nbSales;
+  const costLost = hoursLost * hourlyRate;
+
+  tiles.currentRevenue.textContent = formatCurrency(caActuel);
+  tiles.timeLost.textContent = `Heures perdues estimées : ${formatNumber(hoursLost)} h / mois`;
+  tiles.timeCost.textContent = `Coût du temps perdu : ${formatCurrency(costLost)}`;
+
+  const flow10 = projectFlow(numericState, conversions, scenarioTarget, 1.1);
+  const flow20 = projectFlow(numericState, conversions, scenarioTarget, 1.2);
+
+  const ca10 = flow10.signatures * numericState.averageOrder;
+  const ca20 = flow20.signatures * numericState.averageOrder;
+  const gain10 = Math.max(0, ca10 - caActuel);
+  const gain20 = Math.max(0, ca20 - caActuel);
+
+  tiles.gain10.textContent = formatCurrency(gain10);
+  tiles.ca10.textContent = `CA projeté : ${formatCurrency(ca10)}`;
+  tiles.gain20.textContent = formatCurrency(gain20);
+  tiles.ca20.textContent = `CA projeté : ${formatCurrency(ca20)}`;
+
+  const deltaRaw = (formState.deltaSign ?? '').toString().trim();
+  const deltaRatio = numericState.deltaSign / 100;
+  if (deltaRaw !== '' && deltaRatio > 0 && numericState.quotes > 0) {
+    const newRate = clamp(conversions.tc3 + deltaRatio, 0, 1);
+    const customSignatures = numericState.quotes * newRate;
+    const customCa = customSignatures * numericState.averageOrder;
+    const customGain = Math.max(0, customCa - caActuel);
+    tiles.customGain.textContent = formatCurrency(customGain);
+    tiles.customCa.textContent = `CA projeté : ${formatCurrency(customCa)}`;
+    tiles.customTile.hidden = false;
+  } else {
+    tiles.customTile.hidden = true;
+  }
+
+  if (numericState.adBudget > 0) {
+    const roi10 = gain10 > 0 ? (gain10 - numericState.adBudget) / numericState.adBudget : -1;
+    const roi20 = gain20 > 0 ? (gain20 - numericState.adBudget) / numericState.adBudget : -1;
+    tiles.roi10.textContent = `+10% : ${formatPercent(roi10)}`;
+    tiles.roi20.textContent = `+20% : ${formatPercent(roi20)}`;
+    tiles.roiTile.hidden = false;
+  } else {
+    tiles.roiTile.hidden = true;
+  }
+}
+
+function renderBenchmark(numericState, conversions) {
+  const benchmark = BENCHMARKS[formState.sector] ?? BENCHMARKS.general;
+  const weights = { tc1: 0.35, tc2: 0.25, tc3: 0.4 };
+
+  let globalScore = 0;
+
+  ['tc1', 'tc2', 'tc3'].forEach((step) => {
+    const cells = benchmarkCells[step];
+    const benchValue = benchmark.rates[step];
+    const actual = conversions[step];
+    const denominator = step === 'tc1' ? numericState.visitors : step === 'tc2' ? numericState.leads : numericState.quotes;
+    const hasData = denominator > 0;
+
+    cells.benchmark.textContent = formatPercent(benchValue);
+    cells.actual.textContent = hasData ? formatPercent(actual) : '—';
+
+    let verdict = '↓ En dessous – priorité';
+    let verdictClass = 'verdict-down';
+    if (!hasData) {
+      verdict = 'Données manquantes';
+      verdictClass = 'verdict-mid';
+    } else if (actual >= benchValue) {
+      verdict = '↑ Au-dessus de la moyenne';
+      verdictClass = 'verdict-up';
+    } else if (actual >= benchValue * 0.7) {
+      verdict = '→ Légèrement en dessous';
+      verdictClass = 'verdict-mid';
+    }
+    cells.verdict.textContent = verdict;
+    cells.verdict.classList.remove('verdict-up', 'verdict-mid', 'verdict-down');
+    cells.verdict.classList.add(verdictClass);
+
+    const score = hasData ? clamp(Math.round((actual / benchValue) * 50), 0, 100) : 0;
+    globalScore += score * weights[step];
+  });
+
+  const lBenchmark = numericState.visitors * benchmark.rates.tc1;
+  const dBenchmark = lBenchmark * benchmark.rates.tc2;
+  const sBenchmark = dBenchmark * benchmark.rates.tc3;
+  const caBenchmark = sBenchmark * numericState.averageOrder;
+  const caActuel = numericState.signatures * numericState.averageOrder;
+  const lost = Math.max(0, caBenchmark - caActuel);
+
+  benchmarkSummary.globalScore.textContent = Math.round(globalScore).toString();
+  benchmarkSummary.benchmarkRevenue.textContent = formatCurrency(caBenchmark);
+  benchmarkSummary.lostRevenue.textContent = formatCurrency(lost);
+}
+
+function renderRecommendations(numericState, conversions) {
+  const hasEnoughData =
+    numericState.visitors > 0 &&
+    numericState.leads > 0 &&
+    numericState.quotes > 0 &&
+    numericState.signatures > 0 &&
+    numericState.averageOrder > 0;
+
+  if (!hasEnoughData) {
+    recoList.innerHTML = '';
+    const empty = document.createElement('li');
+    empty.className = 'reco-empty';
+    empty.textContent = 'Complétez vos volumes et votre panier moyen pour générer un plan d’action.';
+    recoList.append(empty);
+    return;
+  }
+
+  const supports = new Set(formState.supports ?? []);
+  const actions = new Map();
+
+  const candidates = [];
+  RECOMMENDATIONS[lastWeakestStep].forEach((item) => candidates.push({ ...item }));
+  if (numericState.reExplain >= 5) {
+    RECOMMENDATIONS.friction.forEach((item) => candidates.push({ ...item }));
+  }
+
+  candidates.forEach((item) => {
+    if (actions.has(item.id)) {
+      return;
+    }
+    const easeBoost = item.boostSupports && item.boostSupports.some((support) => supports.has(support)) ? 1 : 0;
+    const easeScore = clamp(item.ease + easeBoost, 1, 5);
+    const score = item.impact * 0.7 + easeScore * 0.3;
+    actions.set(item.id, { ...item, easeScore, score });
+  });
+
+  const sorted = Array.from(actions.values()).sort((a, b) => b.score - a.score).slice(0, 3);
+
+  recoList.innerHTML = '';
+  sorted.forEach((action) => {
+    const li = document.createElement('li');
+    const title = document.createElement('h3');
+    title.className = 'reco-title';
+    title.textContent = action.title;
+
+    const objective = document.createElement('p');
+    objective.className = 'reco-objective';
+    objective.textContent = action.objective;
+
+    const steps = document.createElement('ul');
+    steps.className = 'reco-steps';
+    action.steps.forEach((step) => {
+      const liStep = document.createElement('li');
+      liStep.textContent = step;
+      steps.append(liStep);
+    });
+
+    const meta = document.createElement('div');
+    meta.className = 'reco-meta';
+    const impact = document.createElement('span');
+    impact.textContent = `Impact : ${action.impact}/5`;
+    const ease = document.createElement('span');
+    ease.textContent = `Facilité : ${action.easeScore}/5`;
+    const effort = document.createElement('span');
+    effort.textContent = `Effort : ${action.effort}`;
+    const duration = document.createElement('span');
+    duration.textContent = `Délai : ${action.duration}`;
+    meta.append(impact, ease, effort, duration);
+
+    li.append(title, objective, steps, meta);
+    recoList.append(li);
+  });
+}
+
+function updateCtaLink() {
+  try {
+    const url = new URL(CTA_BASE_URL);
+    url.searchParams.set('source', 'audit');
+    const mapping = {
+      V: formState.visitors,
+      L: formState.leads,
+      D: formState.quotes,
+      S: formState.signatures,
+      PM: formState.averageOrder,
+      TR: formState.reExplain,
+      B: formState.adBudget,
+      Delta: formState.deltaSign
+    };
+    Object.entries(mapping).forEach(([key, value]) => {
+      const normalized = (value ?? '').toString().trim();
+      if (normalized !== '') {
+        url.searchParams.set(key, normalized);
+      }
+    });
+    const href = `${url.toString()}${CTA_HASH}`;
+    ctaButton.href = href;
+  } catch (error) {
+    ctaButton.href = `${CTA_BASE_URL}${CTA_HASH}`;
+  }
+}
+
+function computeAndRender() {
+  const numericState = getNumericState();
+  const conversions = computeConversions(numericState);
+  const validation = validateInputs(numericState);
+
+  renderValidation(validation);
+  renderFunnel(conversions, numericState);
+  renderChiffrage(numericState, conversions);
+  renderBenchmark(numericState, conversions);
+  renderRecommendations(numericState, conversions);
+  updateCtaLink();
+  saveState();
+}
+
+function bindEvents() {
+  Object.entries(fieldElements).forEach(([name, refs]) => {
+    if (!refs.input) {
+      return;
+    }
+    refs.input.addEventListener('input', (event) => {
+      formState[name] = event.target.value;
+      computeAndRender();
+    });
+  });
+
+  supportsInputs.forEach((input) => {
+    input.addEventListener('change', () => {
+      const selected = supportsInputs.filter((item) => item.checked).map((item) => item.value);
+      formState.supports = selected;
+      computeAndRender();
+    });
+  });
+
+  scenarioSelect.addEventListener('change', (event) => {
+    formState.scenarioMode = event.target.value;
+    computeAndRender();
+  });
+
+  sectorSelect.addEventListener('change', (event) => {
+    formState.sector = event.target.value;
+    computeAndRender();
+  });
+
+  refreshRecommendationsButton.addEventListener('click', () => {
+    computeAndRender();
+  });
+
+  exportButton.addEventListener('click', () => {
+    window.print();
+  });
+
+  document.getElementById('tunnel-form').addEventListener('submit', (event) => {
+    event.preventDefault();
+  });
+}
+
+loadStateFromStorage();
+applyQueryParams();
+syncFormWithState();
+bindEvents();
+computeAndRender();

--- a/design/charte.css
+++ b/design/charte.css
@@ -21,6 +21,10 @@
   --color-input-border: #d1d5db;
   --color-highlight: rgba(47, 128, 237, 0.07);
   --color-kpi-background: #f7f8fa;
+  --color-success: #12b76a;
+  --color-warning: #f79009;
+  --color-danger: #f04438;
+  --color-info: #2563eb;
 
   /* Effets & rayons */
   --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.04);
@@ -48,6 +52,10 @@
     --color-input-border: #2a2a2a;
     --color-highlight: rgba(96, 165, 250, 0.14);
     --color-kpi-background: #161616;
+    --color-success: #4ade80;
+    --color-warning: #fbbf24;
+    --color-danger: #f87171;
+    --color-info: #93c5fd;
     --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.3);
   }
 }

--- a/index.html
+++ b/index.html
@@ -3,73 +3,304 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Simulateur d’opportunités</title>
+    <title>Audit tunnel commercial</title>
     <link rel="stylesheet" href="design/charte.css" />
     <link rel="stylesheet" href="assets/css/app.css" />
     <script src="assets/js/simulator.js" defer></script>
   </head>
   <body>
     <main>
-      <article class="sim-card">
-        <header>
-          <h1>Simulateur d’opportunités</h1>
-          <p>Modifiez les valeurs puis calculez votre projection : aucune donnée n’est envoyée côté serveur.</p>
+      <article class="sim-app">
+        <header class="sim-header">
+          <h1>Audit express du tunnel commercial</h1>
+          <p>
+            Collectez en moins d’une minute les indicateurs clés pour obtenir un diagnostic, un chiffrage et un plan d’actions
+            priorisé. Tous les calculs restent sur votre navigateur.
+          </p>
+          <p class="data-notice">Les données restent sur votre appareil.</p>
+          <div class="header-actions">
+            <button type="button" id="export" class="sim-btn">Exporter le diagnostic (PDF)</button>
+          </div>
         </header>
 
-        <div class="sim-grid" role="group" aria-labelledby="inputs-title">
-          <h2 id="inputs-title" class="visually-hidden">Entrées du simulateur</h2>
-
-          <label>
-            Visites qualifiées / mois
-            <input id="visits" type="number" placeholder="ex. 5000" min="0" inputmode="decimal" />
-          </label>
-
-          <label>
-            Taux de conversion actuel (%)
-            <input id="conv" type="number" placeholder="ex. 1,5" step="0.1" min="0" max="100" inputmode="decimal" />
-          </label>
-
-          <label>
-            Panier moyen (€)
-            <input id="aov" type="number" placeholder="ex. 60" step="0.01" min="0" inputmode="decimal" />
-          </label>
-
-          <label>
-            Amélioration visée (points de %)
-            <input id="delta" type="number" placeholder="ex. 1" step="0.1" min="0" inputmode="decimal" />
-          </label>
-
-          <label>
-            Budget pub mensuel (optionnel) (€)
-            <input id="adspend" type="number" placeholder="ex. 1500" step="1" min="0" inputmode="decimal" />
-          </label>
-
-          <div class="sim-actions">
-            <button type="button" id="calculate" class="sim-btn">Calculer</button>
-            <a class="sim-link" id="cta" href="https://nexus-strategie.fr/Nexus-26fc5cfed6a88039a83beff4f81756fa?source=copy_link#26fc5cfed6a88056a43cf40d86a8200a" target="_blank" rel="noopener">Réserver un audit gratuit (30 min)</a>
+        <section id="section-questionnaire" class="sim-section">
+          <div class="section-title">
+            <span class="section-index">1</span>
+            <div>
+              <h2>Questionnaire</h2>
+              <p>Renseignez les métriques mensuelles de votre entonnoir.</p>
+            </div>
           </div>
-        </div>
 
-        <section class="sim-kpi" aria-live="polite">
-          <article class="sim-box">
-            <h2>CA mensuel actuel (estimé)</h2>
-            <p class="sim-value" id="caActuel">—</p>
-          </article>
-          <article class="sim-box">
-            <h2>Gains potentiels (Δ visée)</h2>
-            <p class="sim-value" id="gain">—</p>
-          </article>
-          <article class="sim-box">
-            <h2>CA mensuel projeté</h2>
-            <p class="sim-value" id="caProjete">—</p>
-          </article>
-          <article class="sim-box">
-            <h2>ROI pub (indicatif)</h2>
-            <p class="sim-value" id="roi">—</p>
-          </article>
+          <form id="tunnel-form" class="form-grid" novalidate>
+            <div class="field" data-field="visitors">
+              <label for="visitors">Visiteurs mensuels (V)</label>
+              <input id="visitors" name="visitors" type="number" inputmode="numeric" placeholder="ex. 5000" min="0" step="1" />
+              <p class="field-hint">Nombre total de visiteurs uniques sur la période.</p>
+              <p class="field-error" data-error="visitors"></p>
+            </div>
+
+            <div class="field" data-field="leads">
+              <label for="leads">Leads entrants / mois (L)</label>
+              <input id="leads" name="leads" type="number" inputmode="numeric" placeholder="ex. 240" min="0" step="1" />
+              <p class="field-hint">Contacts qualifiés ayant laissé leurs coordonnées.</p>
+              <p class="field-error" data-error="leads"></p>
+            </div>
+
+            <div class="field" data-field="quotes">
+              <label for="quotes">Devis envoyés / mois (D)</label>
+              <input id="quotes" name="quotes" type="number" inputmode="numeric" placeholder="ex. 95" min="0" step="1" />
+              <p class="field-hint">Nombre de propositions commerciales émises.</p>
+              <p class="field-error" data-error="quotes"></p>
+            </div>
+
+            <div class="field" data-field="signatures">
+              <label for="signatures">Signatures / mois (S)</label>
+              <input id="signatures" name="signatures" type="number" inputmode="numeric" placeholder="ex. 32" min="0" step="1" />
+              <p class="field-hint">Contrats signés ou ventes conclues.</p>
+              <p class="field-error" data-error="signatures"></p>
+            </div>
+
+            <div class="field" data-field="averageOrder">
+              <label for="averageOrder">Panier moyen (€) (PM)</label>
+              <input id="averageOrder" name="averageOrder" type="number" inputmode="decimal" placeholder="ex. 2800" min="0" step="0.01" />
+              <p class="field-hint">Panier moyen = valeur d’une commande signée.</p>
+              <p class="field-error" data-error="averageOrder"></p>
+            </div>
+
+            <div class="field" data-field="reExplain">
+              <label for="reExplain">Temps moyen “à réexpliquer” par commercial / semaine (h) (TR)</label>
+              <input id="reExplain" name="reExplain" type="number" inputmode="decimal" placeholder="ex. 3" min="0" step="0.1" />
+              <p class="field-hint">Temps passé à reformuler l’offre ou répondre aux mêmes questions.</p>
+              <p class="field-error" data-error="reExplain"></p>
+            </div>
+
+            <fieldset class="field field--full" data-field="supports">
+              <legend>Supports utilisés</legend>
+              <p class="field-hint">Cochez les leviers déjà en place pour ajuster les recommandations.</p>
+              <div class="supports-grid">
+                <label><input type="checkbox" name="supports" value="Site" /> Site web</label>
+                <label><input type="checkbox" name="supports" value="Plaquette" /> Plaquette</label>
+                <label><input type="checkbox" name="supports" value="Emailing" /> Emailing</label>
+                <label><input type="checkbox" name="supports" value="Scripts commerciaux" /> Scripts commerciaux</label>
+                <label><input type="checkbox" name="supports" value="Salons" /> Salons</label>
+                <label><input type="checkbox" name="supports" value="Autre" /> Autre</label>
+              </div>
+            </fieldset>
+
+            <div class="field" data-field="adBudget">
+              <label for="adBudget">Budget pub mensuel (€) (optionnel)</label>
+              <input id="adBudget" name="adBudget" type="number" inputmode="decimal" placeholder="ex. 1500" min="0" step="1" />
+              <p class="field-hint">Servez-vous-en pour estimer le ROI des scénarios.</p>
+              <p class="field-error" data-error="adBudget"></p>
+            </div>
+
+            <div class="field" data-field="deltaSign">
+              <label for="deltaSign">Amélioration visée du taux de conversion final (points de %) (optionnel)</label>
+              <input id="deltaSign" name="deltaSign" type="number" inputmode="decimal" placeholder="ex. 5" min="0" step="0.1" />
+              <p class="field-hint">Points supplémentaires souhaités sur Devis → Signatures.</p>
+              <p class="field-error" data-error="deltaSign"></p>
+            </div>
+
+            <div class="field" data-field="nbSales">
+              <label for="nbSales">Nombre de commerciaux (optionnel)</label>
+              <input id="nbSales" name="nbSales" type="number" inputmode="numeric" placeholder="ex. 4" min="0" step="1" />
+              <p class="field-hint">Par défaut, nous considérons 1 commercial.</p>
+              <p class="field-error" data-error="nbSales"></p>
+            </div>
+
+            <div class="field" data-field="hourlyRate">
+              <label for="hourlyRate">Taux horaire estimé (€) (optionnel)</label>
+              <input id="hourlyRate" name="hourlyRate" type="number" inputmode="decimal" placeholder="ex. 50" min="0" step="1" />
+              <p class="field-hint">Utilisé pour chiffrer le coût des frictions internes.</p>
+              <p class="field-error" data-error="hourlyRate"></p>
+            </div>
+          </form>
+
+          <div class="validation-summary">
+            <h3>Statut des entrées</h3>
+            <div class="validation-flags" role="status" aria-live="polite">
+              <span class="badge" data-summary-badge="visitors">Visiteurs</span>
+              <span class="badge" data-summary-badge="leads">Leads</span>
+              <span class="badge" data-summary-badge="quotes">Devis</span>
+              <span class="badge" data-summary-badge="signatures">Signatures</span>
+              <span class="badge" data-summary-badge="averageOrder">Panier moyen</span>
+              <span class="badge" data-summary-badge="reExplain">Frictions</span>
+            </div>
+            <p class="coherence" id="coherenceBadge"></p>
+          </div>
         </section>
 
-        <p class="sim-footnote">Formule e‑commerce : CA = Visites × (Taux/100) × Panier. Δ = Visites × (Δ points/100) × Panier. ROI = (Δ − Budget) / max(Budget, 1).</p>
+        <section id="section-diagnostic" class="sim-section">
+          <div class="section-title">
+            <span class="section-index">2</span>
+            <div>
+              <h2>Diagnostic visuel</h2>
+              <p>Analyse du tunnel et indice de friction interne.</p>
+            </div>
+          </div>
+
+          <div class="funnel" aria-live="polite">
+            <div class="funnel-steps">
+              <div class="funnel-step" data-step="tc1">
+                <span class="step-label">Visiteurs → Leads</span>
+                <div class="step-bar"><span class="step-fill"></span></div>
+                <span class="step-value" data-tc="tc1">—</span>
+              </div>
+              <div class="funnel-step" data-step="tc2">
+                <span class="step-label">Leads → Devis</span>
+                <div class="step-bar"><span class="step-fill"></span></div>
+                <span class="step-value" data-tc="tc2">—</span>
+              </div>
+              <div class="funnel-step" data-step="tc3">
+                <span class="step-label">Devis → Signatures</span>
+                <div class="step-bar"><span class="step-fill"></span></div>
+                <span class="step-value" data-tc="tc3">—</span>
+              </div>
+            </div>
+            <p class="funnel-message" id="weakLinkMessage"></p>
+            <div class="friction" role="img" aria-label="Indice de friction interne">
+              <span class="friction-label">Indice de friction “explication”</span>
+              <div class="friction-bar"><span class="friction-fill"></span></div>
+              <span class="friction-value" id="frictionValue">0</span>
+            </div>
+          </div>
+        </section>
+
+        <section id="section-chiffrage" class="sim-section">
+          <div class="section-title">
+            <span class="section-index">3</span>
+            <div>
+              <h2>Chiffrage</h2>
+              <p>Gains potentiels sur l’étape limitante ou le closing final.</p>
+            </div>
+          </div>
+
+          <div class="scenario-controls">
+            <label for="scenarioMode">Scénario global</label>
+            <select id="scenarioMode" name="scenarioMode">
+              <option value="weak">+10% / +20% sur l’étape la plus faible</option>
+              <option value="tc3">+10% / +20% sur Devis → Signatures</option>
+            </select>
+          </div>
+
+          <div class="sim-tiles">
+            <article class="sim-tile">
+              <h3>CA mensuel actuel</h3>
+              <p class="sim-value" id="currentRevenue">—</p>
+              <p class="sim-sub" id="timeLostSummary">Heures perdues estimées : —</p>
+              <p class="sim-sub" id="timeCostSummary">Coût du temps perdu : —</p>
+            </article>
+            <article class="sim-tile">
+              <h3>Gains potentiels +10%</h3>
+              <p class="sim-value" id="gain10">—</p>
+              <p class="sim-sub" id="ca10">CA projeté : —</p>
+            </article>
+            <article class="sim-tile">
+              <h3>Gains potentiels +20%</h3>
+              <p class="sim-value" id="gain20">—</p>
+              <p class="sim-sub" id="ca20">CA projeté : —</p>
+            </article>
+            <article class="sim-tile" id="customGainTile">
+              <h3>Objectif utilisateur</h3>
+              <p class="sim-value" id="customGain">—</p>
+              <p class="sim-sub" id="customCa">CA projeté : —</p>
+            </article>
+            <article class="sim-tile" id="roiTile">
+              <h3>ROI publicitaire (indicatif)</h3>
+              <p class="sim-value" id="roi10">+10% : —</p>
+              <p class="sim-sub" id="roi20">+20% : —</p>
+            </article>
+          </div>
+        </section>
+
+        <section id="section-benchmark" class="sim-section">
+          <div class="section-title">
+            <span class="section-index">4</span>
+            <div>
+              <h2>Benchmarking</h2>
+              <p>Comparez vos taux aux moyennes sectorielles.</p>
+            </div>
+          </div>
+
+          <div class="benchmark-controls">
+            <label for="sector">Secteur analysé</label>
+            <select id="sector" name="sector">
+              <option value="general">Général B2B</option>
+              <option value="industrie">Industrie</option>
+              <option value="services">Services B2B</option>
+              <option value="equipementiers">Équipementiers</option>
+            </select>
+          </div>
+
+          <table class="benchmark-table">
+            <thead>
+              <tr>
+                <th>Étape</th>
+                <th>Benchmark</th>
+                <th>Votre taux</th>
+                <th>Verdict</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr data-row="tc1">
+                <th scope="row">Visiteur → Lead</th>
+                <td data-benchmark="tc1">—</td>
+                <td data-actual="tc1">—</td>
+                <td data-verdict="tc1">—</td>
+              </tr>
+              <tr data-row="tc2">
+                <th scope="row">Lead → Devis</th>
+                <td data-benchmark="tc2">—</td>
+                <td data-actual="tc2">—</td>
+                <td data-verdict="tc2">—</td>
+              </tr>
+              <tr data-row="tc3">
+                <th scope="row">Devis → Signature</th>
+                <td data-benchmark="tc3">—</td>
+                <td data-actual="tc3">—</td>
+                <td data-verdict="tc3">—</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <div class="benchmark-summary">
+            <div class="score-card">
+              <span class="score-label">Score global</span>
+              <span class="score-value" id="globalScore">0</span>
+            </div>
+            <div class="benchmark-kpis">
+              <p>CA benchmark estimé : <strong id="benchmarkRevenue">—</strong></p>
+              <p>Manque à gagner potentiel : <strong id="lostRevenue">—</strong></p>
+            </div>
+          </div>
+        </section>
+
+        <section id="section-reco" class="sim-section">
+          <div class="section-title">
+            <span class="section-index">5</span>
+            <div>
+              <h2>Plan d’action priorisé</h2>
+              <p>3 leviers maximum, classés par impact et facilité.</p>
+            </div>
+          </div>
+
+          <ol class="reco-list" id="recoList"></ol>
+          <div class="reco-cta">
+            <button type="button" id="refreshRecommendations" class="sim-link">Mettre à jour les recommandations</button>
+          </div>
+        </section>
+
+        <section id="section-cta" class="sim-section">
+          <div class="section-title">
+            <span class="section-index">6</span>
+            <div>
+              <h2>Passer à l’action</h2>
+            </div>
+          </div>
+          <p class="cta-text">Voici vos 3 leviers immédiats. Voulez-vous qu’on en parle pour les activer rapidement ?</p>
+          <a class="cta-button" id="cta" href="#" target="_blank" rel="noopener">Prendre RDV pour passer à l’action</a>
+        </section>
       </article>
     </main>
   </body>


### PR DESCRIPTION
## Summary
- reconstruire l’interface autour de six sections : questionnaire, diagnostic, chiffrage, benchmark, plan d’action et CTA
- ajouter toutes les validations, calculs et projections côté navigateur avec persistance locale et préremplissage via URL
- enrichir les styles et la charte pour couvrir les nouveaux composants, les badges de statut et l’export PDF

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c961c388a88320aab0c40c8d25a12d