### PR TITLE
Supprimer les CTA obsolètes et déplacer le bouton d'export

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -773,7 +773,7 @@ a:hover {
   }
 
   .header-actions,
-  #refreshRecommendations {
+  #export {
     display: none !important;
   }
 }

--- a/assets/js/simulator.js
+++ b/assets/js/simulator.js
@@ -4,8 +4,6 @@
  */
 
 const STORAGE_KEY = 'audit-tunnel-state-v1';
-const CTA_BASE_URL = 'https://nexus-strategie.fr/Nexus-26fc5cfed6a88039a83beff4f81756fa';
-const CTA_HASH = '#26fc5cfed6a88056a43cf40d86a8200a';
 
 const DEFAULT_STATE = {
   visitors: '',
@@ -116,7 +114,6 @@ const scenarioSelect = document.getElementById('scenarioMode');
 const sectorSelect = document.getElementById('sector');
 const coherenceBadge = document.getElementById('coherenceBadge');
 const exportButton = document.getElementById('export');
-const ctaButton = document.getElementById('cta');
 
 const funnelSteps = {
   tc1: {
@@ -181,7 +178,6 @@ const benchmarkSummary = {
 };
 
 const recoList = document.getElementById('recoList');
-const refreshRecommendationsButton = document.getElementById('refreshRecommendations');
 
 let formState = deepClone(DEFAULT_STATE);
 let lastWeakestStep = 'tc3';
@@ -818,33 +814,6 @@ function renderRecommendations(numericState, conversions) {
   });
 }
 
-function updateCtaLink() {
-  try {
-    const url = new URL(CTA_BASE_URL);
-    url.searchParams.set('source', 'audit');
-    const mapping = {
-      V: formState.visitors,
-      L: formState.leads,
-      D: formState.quotes,
-      S: formState.signatures,
-      PM: formState.averageOrder,
-      TR: formState.reExplain,
-      B: formState.adBudget,
-      Delta: formState.deltaSign
-    };
-    Object.entries(mapping).forEach(([key, value]) => {
-      const normalized = (value ?? '').toString().trim();
-      if (normalized !== '') {
-        url.searchParams.set(key, normalized);
-      }
-    });
-    const href = `${url.toString()}${CTA_HASH}`;
-    ctaButton.href = href;
-  } catch (error) {
-    ctaButton.href = `${CTA_BASE_URL}${CTA_HASH}`;
-  }
-}
-
 function computeAndRender() {
   const numericState = getNumericState();
   const conversions = computeConversions(numericState);
@@ -855,7 +824,6 @@ function computeAndRender() {
   renderChiffrage(numericState, conversions);
   renderBenchmark(numericState, conversions);
   renderRecommendations(numericState, conversions);
-  updateCtaLink();
   saveState();
 }
 
@@ -885,10 +853,6 @@ function bindEvents() {
 
   sectorSelect.addEventListener('change', (event) => {
     formState.sector = event.target.value;
-    computeAndRender();
-  });
-
-  refreshRecommendationsButton.addEventListener('click', () => {
     computeAndRender();
   });
 

--- a/index.html
+++ b/index.html
@@ -18,9 +18,6 @@
             priorisé. Tous les calculs restent sur votre navigateur.
           </p>
           <p class="data-notice">Les données restent sur votre appareil.</p>
-          <div class="header-actions">
-            <button type="button" id="export" class="sim-btn">Exporter le diagnostic (PDF)</button>
-          </div>
         </header>
 
         <section id="section-questionnaire" class="sim-section">
@@ -286,9 +283,6 @@
           </div>
 
           <ol class="reco-list" id="recoList"></ol>
-          <div class="reco-cta">
-            <button type="button" id="refreshRecommendations" class="sim-link">Mettre à jour les recommandations</button>
-          </div>
         </section>
 
         <section id="section-cta" class="sim-section">
@@ -299,7 +293,7 @@
             </div>
           </div>
           <p class="cta-text">Voici vos 3 leviers immédiats. Voulez-vous qu’on en parle pour les activer rapidement ?</p>
-          <a class="cta-button" id="cta" href="#" target="_blank" rel="noopener">Prendre RDV pour passer à l’action</a>
+          <button type="button" id="export" class="sim-btn">Exporter le diagnostic (PDF)</button>
         </section>
       </article>
     </main>


### PR DESCRIPTION
## Summary
- retirer les boutons "Mettre à jour les recommandations" et "Prendre RDV" des sections 5 et 6
- déplacer le bouton d'export PDF vers la fin de la section 6
- nettoyer la logique JS et les styles associés aux CTA supprimés

## Testing
- non applicable

------
https://chatgpt.com/codex/tasks/task_e_68c98f2b3d70832095f1d1f4ea8f5eba