### PR TITLE
Ajoute un récapitulatif dynamique au CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
           <form id="tunnel-form" class="form-grid" novalidate>
             <div class="field" data-field="visitors">
               <label for="visitors" class="has-tooltip" data-tooltip="Nombre total de visiteurs uniques sur la période." title="Nombre total de visiteurs uniques sur la période.">
-                Visiteurs mensuels (V)
+                Combien de visiteurs uniques accueillez-vous chaque mois&nbsp;? (V)
                 <span class="tooltip-icon" aria-hidden="true">?</span>
               </label>
               <input id="visitors" name="visitors" type="number" inputmode="numeric" placeholder="ex. 5000" min="0" step="1" />
@@ -42,7 +42,7 @@
 
             <div class="field" data-field="leads">
               <label for="leads" class="has-tooltip" data-tooltip="Contacts qualifiés ayant laissé leurs coordonnées." title="Contacts qualifiés ayant laissé leurs coordonnées.">
-                Leads entrants / mois (L)
+                Combien de leads entrants obtenez-vous par mois&nbsp;? (L)
                 <span class="tooltip-icon" aria-hidden="true">?</span>
               </label>
               <input id="leads" name="leads" type="number" inputmode="numeric" placeholder="ex. 240" min="0" step="1" />
@@ -52,7 +52,7 @@
 
             <div class="field" data-field="quotes">
               <label for="quotes" class="has-tooltip" data-tooltip="Nombre de propositions commerciales émises." title="Nombre de propositions commerciales émises.">
-                Devis envoyés / mois (D)
+                Combien de devis envoyez-vous chaque mois&nbsp;? (D)
                 <span class="tooltip-icon" aria-hidden="true">?</span>
               </label>
               <input id="quotes" name="quotes" type="number" inputmode="numeric" placeholder="ex. 95" min="0" step="1" />
@@ -62,7 +62,7 @@
 
             <div class="field" data-field="signatures">
               <label for="signatures" class="has-tooltip" data-tooltip="Contrats signés ou ventes conclues." title="Contrats signés ou ventes conclues.">
-                Signatures / mois (S)
+                Combien de signatures concluez-vous par mois&nbsp;? (S)
                 <span class="tooltip-icon" aria-hidden="true">?</span>
               </label>
               <input id="signatures" name="signatures" type="number" inputmode="numeric" placeholder="ex. 32" min="0" step="1" />
@@ -72,7 +72,7 @@
 
             <div class="field" data-field="averageOrder">
               <label for="averageOrder" class="has-tooltip" data-tooltip="Valeur moyenne d’une commande signée." title="Valeur moyenne d’une commande signée.">
-                Panier moyen (€) (PM)
+                Quel est votre panier moyen par signature&nbsp;? (PM)
                 <span class="tooltip-icon" aria-hidden="true">?</span>
               </label>
               <input id="averageOrder" name="averageOrder" type="number" inputmode="decimal" placeholder="ex. 2800" min="0" step="0.01" />
@@ -82,7 +82,7 @@
 
             <div class="field" data-field="reExplain">
               <label for="reExplain" class="has-tooltip" data-tooltip="Temps passé à reformuler l’offre ou répondre aux mêmes questions." title="Temps passé à reformuler l’offre ou répondre aux mêmes questions.">
-                Temps moyen “à réexpliquer” par commercial / semaine (h) (TR)
+                Combien d’heures vos commerciaux réexpliquent-ils l’offre chaque semaine&nbsp;? (TR)
                 <span class="tooltip-icon" aria-hidden="true">?</span>
               </label>
               <input id="reExplain" name="reExplain" type="number" inputmode="decimal" placeholder="ex. 3" min="0" step="0.1" />
@@ -92,7 +92,7 @@
 
             <fieldset class="field field--full" data-field="supports">
               <legend class="has-tooltip" data-tooltip="Cochez les leviers déjà en place pour ajuster les recommandations." title="Cochez les leviers déjà en place pour ajuster les recommandations.">
-                Supports utilisés
+                Quels supports utilisez-vous déjà&nbsp;?
                 <span class="tooltip-icon" aria-hidden="true">?</span>
               </legend>
               <p class="field-hint">Cochez les leviers déjà en place pour ajuster les recommandations.</p>
@@ -108,7 +108,7 @@
 
             <div class="field" data-field="adBudget">
               <label for="adBudget" class="has-tooltip" data-tooltip="Montant dépensé chaque mois en publicité payante." title="Montant dépensé chaque mois en publicité payante.">
-                Budget pub mensuel (€) (optionnel)
+                Quel budget publicitaire investissez-vous chaque mois&nbsp;? (optionnel)
                 <span class="tooltip-icon" aria-hidden="true">?</span>
               </label>
               <input id="adBudget" name="adBudget" type="number" inputmode="decimal" placeholder="ex. 1500" min="0" step="1" />
@@ -118,7 +118,7 @@
 
             <div class="field" data-field="deltaSign">
               <label for="deltaSign" class="has-tooltip" data-tooltip="Points supplémentaires souhaités entre Devis et Signatures." title="Points supplémentaires souhaités entre Devis et Signatures.">
-                Amélioration visée du taux de conversion final (points de %) (optionnel)
+                De combien de points souhaitez-vous améliorer Devis → Signatures&nbsp;? (optionnel)
                 <span class="tooltip-icon" aria-hidden="true">?</span>
               </label>
               <input id="deltaSign" name="deltaSign" type="number" inputmode="decimal" placeholder="ex. 5" min="0" step="0.1" />
@@ -128,7 +128,7 @@
 
             <div class="field" data-field="nbSales">
               <label for="nbSales" class="has-tooltip" data-tooltip="Effectif des personnes en charge de la vente." title="Effectif des personnes en charge de la vente.">
-                Nombre de commerciaux (optionnel)
+                Combien de commerciaux prennent en charge la vente&nbsp;? (optionnel)
                 <span class="tooltip-icon" aria-hidden="true">?</span>
               </label>
               <input id="nbSales" name="nbSales" type="number" inputmode="numeric" placeholder="ex. 4" min="0" step="1" />
@@ -138,7 +138,7 @@
 
             <div class="field" data-field="hourlyRate">
               <label for="hourlyRate" class="has-tooltip" data-tooltip="Coût horaire moyen d’un commercial pour valoriser le temps passé." title="Coût horaire moyen d’un commercial pour valoriser le temps passé.">
-                Taux horaire estimé (€) (optionnel)
+                Quel est le coût horaire moyen d’un commercial&nbsp;? (optionnel)
                 <span class="tooltip-icon" aria-hidden="true">?</span>
               </label>
               <input id="hourlyRate" name="hourlyRate" type="number" inputmode="decimal" placeholder="ex. 50" min="0" step="1" />
@@ -334,7 +334,9 @@
               <h2>Passer à l’action</h2>
             </div>
           </div>
-          <p class="cta-text">Voici vos 3 leviers immédiats. Voulez-vous qu’on en parle pour les activer rapidement ?</p>
+          <div id="ctaSummary" class="cta-summary" aria-live="polite">
+            <p class="cta-text">Complétez le formulaire pour obtenir un récapitulatif personnalisé.</p>
+          </div>
           <button type="button" id="export" class="sim-btn">Exporter le diagnostic (PDF)</button>
         </section>
       </article>


### PR DESCRIPTION
## Summary
- transforme les libellés du questionnaire en questions directes pour alimenter la synthèse finale
- remplace le texte statique du CTA par un conteneur prêt à recevoir un diagnostic personnalisé
- calcule et affiche dynamiquement un résumé d’investissement, de priorité de conversion et de gains potentiels dans la section 6

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9e3551d0483209e59f5bb09ec79fb